### PR TITLE
Grid function fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hopefully, I will keep this up-to-date with the main PostCactus branch, but it i
 of what I am supporting here is not publicly available, nor under active development, so there is a limit to how
 much development effort should go into this fork.
 Also, since the Illinois code is an example of a Cactus code that PostCactus doesn't natively support, should't
-it be called "PostEinsteinToolkit"? Food for thought.
+it really be called "PostEinsteinToolkit"? Discuss!
 
 # PostCactus
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 license](https://img.shields.io/badge/License-GPLv3-blue.svg)](http://perso.crans.org/besson/LICENSE.html)
 [![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/Sbozzolo/PostCactus/?ref=repository-badge)
 
+# PostCactus-IL Compatible Fork!
+This is a fork of the main PostCactus 3+ repository, with additions to support use with the
+Illinois GRMHD code, which formats some of its output ever so slightly differently than the Einstein Toolkit,
+and as a result evades PostCactus's attempts to read in all scalars, as well as Psi4 data.
+Hopefully, I will keep this up-to-date with the main PostCactus branch, but it is worth remembering that much
+of what I am supporting here is not publicly available, nor under active development, so there is a limit to how
+much development effort should go into this fork.
+Also, since the Illinois code is an example of a Cactus code that PostCactus doesn't natively support, should't
+it be called "PostEinsteinToolkit"? Food for thought.
+
 # PostCactus
 
 PostCactus is a Python library to analyze simulations performed with the

--- a/postcactus/cactus_grid_functions.py
+++ b/postcactus/cactus_grid_functions.py
@@ -845,7 +845,12 @@ class OneGridFunctionH5(BaseOneGridFunction):
         # The default value of these parameters is yes
         with h5py.File(path, "r") as f:
             parameters = f["Parameters and Global Attributes"]
-            all_pars = parameters["All Parameters"][()].decode().split("\n")
+            all_pars = (
+                parameters["All Parameters"][()]
+                .tostring()
+                .decode()
+                .split("\n")
+            )
             # We make sure that everything is lowercase, we are case insensitive
             iohdf5_pars = [
                 param.lower()

--- a/postcactus/cactus_scalars.py
+++ b/postcactus/cactus_scalars.py
@@ -22,6 +22,7 @@ is normally not used directly, but from the :py:mod:`~.simdir` module.
 The data loaded by this module is represented as
 :py:class:`~.TimeSeries` objects.
 """
+#test change
 
 import os
 import re

--- a/postcactus/cactus_scalars.py
+++ b/postcactus/cactus_scalars.py
@@ -22,7 +22,6 @@ is normally not used directly, but from the :py:mod:`~.simdir` module.
 The data loaded by this module is represented as
 :py:class:`~.TimeSeries` objects.
 """
-#test change
 
 import os
 import re

--- a/postcactus/cactus_scalars.py
+++ b/postcactus/cactus_scalars.py
@@ -274,7 +274,7 @@ class TwoScalar:
             file_name_segment1,
             file_name_segment2,
             file_name_segment3,
-            extraction_radius_number
+            extraction_radius_number,
             compression_method,
         ) = filename_match.groups()
 
@@ -418,8 +418,18 @@ class AllScalars:
                             folder
                         ] = cactusascii_file
             except RuntimeError:
-                pass
-
+                try:
+                    cactusascii_file = TwoScalar(file_)
+                    if cactusascii_file.reduction_type == reduction_type:
+                        for var in list(cactusascii_file.keys()):
+                            # We add to the _vars dictionary the mapping:
+                            # [var][folder] to OneScalar(f)
+                            folder = cactusascii_file.folder
+                            self._vars.setdefault(var, {})[
+                                folder
+                            ] = cactusascii_file
+                except RuntimeError:
+                    pass
         # What pythonize_name_dict does is to make the various variables
         # accessible as attributes, e.g. self.fields.rho
         self.fields = pythonize_name_dict(list(self.keys()), self.__getitem__)


### PR DESCRIPTION
**Please ignore the earlier commits, and _only pay attention to the most recent commit, 687e28a_. This is a one-line change**.

Problem:
cactus_grid_functions.py fails on all the grid data I have tried to read. The problem is reading strings from some of the h5py output: at a certain point, .decode() is called on numpy arrays, but the types of the arrays aren't always correct. In my files, these read as single-byte integer arrays (type '|i1'), which have no decode() method. The solution seems to be to call .tostring() on them first, which changes their type (the name is a misnomer), and then decode() works after that, as in this basic example:
>>> arr = np.array([65, 65, 65, 66], dtype='|i1') # 'AAAB'
>>> arr[()].decode()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'numpy.ndarray' object has no attribute 'decode'
>>> arr[()].tostring().decode()
'AAAB'

I have added this to the code, and all the unit tests seem to work, but I can't easily check whether this change causes trouble for grid output from the normal Einstein toolkit thorns, so that should be checked before adding this to the main repo.